### PR TITLE
chore(ci): only trigger autorelease workflow on release PRs

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -4,6 +4,7 @@ name: auto-release
 jobs:
   approve:
     runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'release-v')
     steps:
     - uses: actions/github-script@v3.0.0
       with:


### PR DESCRIPTION
since only release PRs should be evaluated and also YOSHI_TOKEN is not shared on forked PRs