### PR TITLE
docs(samples): update AWS sample due to API changes

### DIFF
--- a/samples/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
+++ b/samples/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
@@ -17,6 +17,7 @@
 package com.example.bigqueryconnection;
 
 // [START bigqueryconnection_create_aws_connection]
+import com.google.cloud.bigquery.connection.v1.AwsAccessRole;
 import com.google.cloud.bigquery.connection.v1.AwsCrossAccountRole;
 import com.google.cloud.bigquery.connection.v1.AwsProperties;
 import com.google.cloud.bigquery.connection.v1.Connection;
@@ -54,12 +55,12 @@ public class CreateAwsConnection {
               .setConnectionId(connectionId)
               .build();
       Connection response = client.createConnection(request);
-      AwsCrossAccountRole role = response.getAws().getCrossAccountRole();
+      AwsAccessRole role = response.getAws().getAccessRole();
       System.out.println(
           "Aws connection created successfully : Aws userId :"
-              + role.getIamUserId()
+              + role.getIamRoleId()
               + " Aws externalId :"
-              + role.getExternalId());
+              + role.getIdentity());
     }
   }
 }

--- a/samples/snippets/src/test/java/com/example/bigqueryconnection/CreateAwsConnectionIT.java
+++ b/samples/snippets/src/test/java/com/example/bigqueryconnection/CreateAwsConnectionIT.java
@@ -19,7 +19,7 @@ package com.example.bigqueryconnection;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
-import com.google.cloud.bigquery.connection.v1.AwsCrossAccountRole;
+import com.google.cloud.bigquery.connection.v1.AwsAccessRole;
 import com.google.cloud.bigquery.connection.v1.AwsProperties;
 import com.google.cloud.bigquery.connection.v1.Connection;
 import java.io.ByteArrayOutputStream;
@@ -83,8 +83,8 @@ public class CreateAwsConnectionIT {
   @Test
   public void testCreateAwsConnection() throws IOException {
     String iamRoleId = String.format("arn:aws:iam::%s:role/%s", AWS_ACCOUNT_ID, AWS_ROLE_ID);
-    AwsCrossAccountRole role = AwsCrossAccountRole.newBuilder().setIamRoleId(iamRoleId).build();
-    AwsProperties awsProperties = AwsProperties.newBuilder().setCrossAccountRole(role).build();
+    AwsAccessRole awsRole = AwsAccessRole.newBuilder().setIamRoleId(iamRoleId).build();
+    AwsProperties awsProperties = AwsProperties.newBuilder().setAccessRole(awsRole).build();
     Connection connection = Connection.newBuilder().setAws(awsProperties).build();
     CreateAwsConnection.createAwsConnection(PROJECT_ID, LOCATION, connectionId, connection);
     assertThat(bout.toString()).contains("Aws connection created successfully :");


### PR DESCRIPTION
AwsCrossAccountRole is replaced with AwsAccessRole
Fixes #571
