### PR TITLE
sample: remove AwsCrossAccountRole from AWS sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigqueryconnection:2.19.0'
+implementation 'com.google.cloud:google-cloud-bigqueryconnection:2.20.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigqueryconnection" % "2.19.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigqueryconnection" % "2.20.0"
 ```
 
 ## Authentication

--- a/samples/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
+++ b/samples/snippets/src/main/java/com/example/bigqueryconnection/CreateAwsConnection.java
@@ -18,7 +18,6 @@ package com.example.bigqueryconnection;
 
 // [START bigqueryconnection_create_aws_connection]
 import com.google.cloud.bigquery.connection.v1.AwsAccessRole;
-import com.google.cloud.bigquery.connection.v1.AwsCrossAccountRole;
 import com.google.cloud.bigquery.connection.v1.AwsProperties;
 import com.google.cloud.bigquery.connection.v1.Connection;
 import com.google.cloud.bigquery.connection.v1.CreateConnectionRequest;
@@ -37,8 +36,8 @@ public class CreateAwsConnection {
     String connectionId = "MY_CONNECTION_ID";
     // Example of role id: arn:aws:iam::accountId:role/myrole
     String iamRoleId = "MY_AWS_ROLE_ID";
-    AwsCrossAccountRole role = AwsCrossAccountRole.newBuilder().setIamRoleId(iamRoleId).build();
-    AwsProperties awsProperties = AwsProperties.newBuilder().setCrossAccountRole(role).build();
+    AwsAccessRole role = AwsAccessRole.newBuilder().setIamRoleId(iamRoleId).build();
+    AwsProperties awsProperties = AwsProperties.newBuilder().setAccessRole(role).build();
     Connection connection = Connection.newBuilder().setAws(awsProperties).build();
     createAwsConnection(projectId, location, connectionId, connection);
   }


### PR DESCRIPTION
fix: remove AwsCrossAccountRole from AWS sample.

This was updated in https://github.com/googleapis/java-bigqueryconnection/pull/576/files, but one reference to AwsCrossAccountRole was not changed, which causes the sample to not work as the cross account role is no longer supported.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigqueryconnection/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
